### PR TITLE
Add `fill` option

### DIFF
--- a/Sources/WallpaperCLI/main.swift
+++ b/Sources/WallpaperCLI/main.swift
@@ -45,18 +45,37 @@ func convertStringToScale(_ scale: String?) -> Wallpaper.Scale {
 	}
 }
 
+func convertStringToFill(_ fill: String?) -> NSColor? {
+	guard let fill = fill else {
+		return nil
+	}
+
+	guard let rgb = Int(fill, radix: 16), fill.count == 6 else {
+		print("Invalid `--fill` value", to: .standardError)
+		exit(1)
+	}
+
+	let red = CGFloat((rgb >> 16) & 0xFF) / 255.0
+	let green = CGFloat((rgb >> 8) & 0xFF) / 255.0
+	let blue = CGFloat(rgb & 0xFF) / 255.0
+
+	return NSColor(red: red, green: green, blue: blue, alpha: 0)
+}
+
 final class SetCommand: Command {
 	let name = "set"
 	let shortDescription = "Set wallpaper image"
 	let path = Parameter()
 	let screen = Key<String>("--screen", description: "Values: all, main, <index> [Default: all]")
 	let scale = Key<String>("--scale", description: "Values: auto, fill, fit, stretch, center [Default: auto]")
+	let fill = Key<String>("--fill", description: "Format: Hex color <RRGGBB> [Default: nil]")
 
 	func execute() throws {
 		try Wallpaper.set(
 			URL(fileURLWithPath: path.value),
 			screen: convertStringToScreen(screen.value),
-			scale: convertStringToScale(scale.value)
+			scale: convertStringToScale(scale.value),
+			fill: convertStringToFill(fill.value)
 		)
 	}
 }

--- a/Sources/wallpaper/Wallpaper.swift
+++ b/Sources/wallpaper/Wallpaper.swift
@@ -83,7 +83,7 @@ public struct Wallpaper {
 	}
 
 	/// Set an image URL as wallpaper
-	public static func set(_ image: URL, screen: Screen = .all, scale: Scale = .auto) throws {
+	public static func set(_ image: URL, screen: Screen = .all, scale: Scale = .auto, fill: NSColor? = nil) throws {
 		var options = [NSWorkspace.DesktopImageOptionKey: Any]()
 
 		switch scale {
@@ -102,6 +102,8 @@ public struct Wallpaper {
 			options[.imageScaling] = NSImageScaling.scaleNone.rawValue
 			options[.allowClipping] = false
 		}
+
+		options[.fillColor] = fill
 
 		try forceRefreshIfNeeded(image, screen: screen)
 

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Set wallpaper image
 Options:
   --scale <value>     Values: auto, fill, fit, stretch, center [Default: auto]
   --screen <value>    Values: all, main, <index> [Default: all]
+  --fill <value>      Format: Hex color <RRGGBB> [Default: nil]
   -h, --help          Show help information
 ```
 
@@ -99,7 +100,7 @@ import Wallpaper
 
 let imageURL = URL(fileURLWithPath: "<path>")
 
-try! Wallpaper.set(imageURL, screen: .main, scale: .fill)
+try! Wallpaper.set(imageURL, screen: .main, scale: .fill, fill: "FF0000")
 
 print(try! Wallpaper.get(screen: .main))
 ```


### PR DESCRIPTION
I added support for the [`fillColor`](https://developer.apple.com/documentation/appkit/nsworkspace/desktopimageoptionkey/1535407-fillcolor) property to the API and made it accessible through the CLI-option `--fill`. Setting the background color without an image URL is not possible, though I looked into the way the system prefpane allows you to choose a custom color. Apparently it stores a transparent picture in the bundles' resources: `/System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane/Contents/Resources/DesktopPictures.prefPane/Contents/Resources/Transparent.tiff`. It might be possible to use this image to add the additional functionality of setting a solid color background to the CLI.

Resolves #19