### PR TITLE
Add `set-solid-color` command

### DIFF
--- a/Sources/WallpaperCLI/main.swift
+++ b/Sources/WallpaperCLI/main.swift
@@ -79,12 +79,12 @@ final class SetCommand: Command {
 final class SetSolidColorCommand: Command {
 	let name = "set-solid-color"
 	let shortDescription = "Set solid color wallpaper background"
-	let solidColor = Parameter()
+	let color = Parameter()
 	let screen = Key<String>("--screen", description: "Values: all, main, <index> [Default: all]")
 
 	func execute() throws {
-		guard let color = NSColor(hexString: solidColor.value) else {
-			print("Invalid `solidColor` value", to: .standardError)
+		guard let color = NSColor(hexString: color.value) else {
+			print("Invalid `color` value", to: .standardError)
 			exit(1)
 		}
 

--- a/Sources/WallpaperCLI/main.swift
+++ b/Sources/WallpaperCLI/main.swift
@@ -76,6 +76,25 @@ final class SetCommand: Command {
 	}
 }
 
+final class SetSolidColorCommand: Command {
+	let name = "set-solid-color"
+	let shortDescription = "Set solid color wallpaper background"
+	let solidColor = Parameter()
+	let screen = Key<String>("--screen", description: "Values: all, main, <index> [Default: all]")
+
+	func execute() throws {
+		guard let color = NSColor(hexString: solidColor.value) else {
+			print("Invalid `solidColor` value", to: .standardError)
+			exit(1)
+		}
+
+		try Wallpaper.set(
+			color,
+			screen: convertStringToScreen(screen.value)
+		)
+	}
+}
+
 final class GetCommand: Command {
 	let name = "get"
 	let shortDescription = "Get current wallpaper image"
@@ -105,6 +124,7 @@ let cli = CLI(
 
 cli.commands = [
 	SetCommand(),
+	SetSolidColorCommand(),
 	GetCommand(),
 	ScreensCommand()
 ]

--- a/Sources/wallpaper/Wallpaper.swift
+++ b/Sources/wallpaper/Wallpaper.swift
@@ -112,6 +112,15 @@ public struct Wallpaper {
 		}
 	}
 
+	/// Set a solid color as wallpaper.
+	public static func set(_ solidColor: NSColor, screen: Screen = .all) throws {
+		let prefPanesDirectory = try FileManager.default.url(for: .preferencePanesDirectory, in: .systemDomainMask, appropriateFor: nil, create: false)
+		let desktopPrefPane = prefPanesDirectory.appendingPathComponent("DesktopScreenEffectsPref.prefPane/Contents/Resources/DesktopPictures.prefPane")
+		let transparentImage = desktopPrefPane.appendingPathComponent("Contents/Resources/Transparent.tiff")
+
+		try set(transparentImage, screen: screen, scale: .fit, fillColor: solidColor)
+	}
+
 	/// Names of available screens.
 	public static var screenNames: [String] {
 		NSScreen.screens.map(\.name)

--- a/Sources/wallpaper/Wallpaper.swift
+++ b/Sources/wallpaper/Wallpaper.swift
@@ -114,9 +114,7 @@ public struct Wallpaper {
 
 	/// Set a solid color as wallpaper.
 	public static func set(_ solidColor: NSColor, screen: Screen = .all) throws {
-		let prefPanesDirectory = try FileManager.default.url(for: .preferencePanesDirectory, in: .systemDomainMask, appropriateFor: nil, create: false)
-		let desktopPrefPane = prefPanesDirectory.appendingPathComponent("DesktopScreenEffectsPref.prefPane/Contents/Resources/DesktopPictures.prefPane")
-		let transparentImage = desktopPrefPane.appendingPathComponent("Contents/Resources/Transparent.tiff")
+		let transparentImage = URL(fileURLWithPath: "/System/Library/PreferencePanes/DesktopScreenEffectsPref.prefPane/Contents/Resources/DesktopPictures.prefPane/Contents/Resources/Transparent.tiff")
 
 		try set(transparentImage, screen: screen, scale: .fit, fillColor: solidColor)
 	}

--- a/readme.md
+++ b/readme.md
@@ -34,11 +34,12 @@ Usage: wallpaper <command> [options]
 Manage the desktop wallpaper
 
 Commands:
-  set             Set wallpaper image
-  get             Get current wallpaper image
-  screens         List screens
-  help            Prints help information
-  version         Prints the current version of this app
+  set               Set wallpaper image
+  set-solid-color   Set solid color wallpaper background
+  get               Get current wallpaper image
+  screens           List screens
+  help              Prints help information
+  version           Prints the current version of this app
 ```
 
 ```
@@ -67,10 +68,28 @@ Options:
   -h, --help              Show help information
 ```
 
+```
+$ wallpaper set-solid-color --help
+
+Usage: wallpaper set-solid-color <color> [options]
+
+Set solid color wallpaper background
+
+Options:
+  --screen <value>        Values: all, main, <index> [Default: all]
+  -h, --help              Show help information
+```
+
 ##### Set
 
 ```
 $ wallpaper set unicorn.jpg
+```
+
+##### Set solid color
+
+```
+$ wallpaper set-solid-color 0000ff
 ```
 
 ##### Get
@@ -96,8 +115,11 @@ Swift Package Manager:
 import Wallpaper
 
 let imageURL = URL(fileURLWithPath: "<path>")
+let solidColor = NSColor.blue
 
 try! Wallpaper.set(imageURL, screen: .main, scale: .fill, fillColor: NSColor.blue)
+
+try! Wallpaper.set(solidColor, screen: .main)
 
 print(try! Wallpaper.get(screen: .main))
 ```


### PR DESCRIPTION
I added a `set-solid-color` command that allows setting the desktop wallpaper to a solid colored background. The error-checking for the solid color is very similar to the `convertStringToFillColor` function, except for the different error message (I'm not sure if you want to keep them separate). If you're happy with the CLI design, I'll add the missing documentation to the README.

Resolves #19


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#19: Support setting a solid color](https://issuehunt.io/repos/33349433/issues/19)
---
</details>
<!-- /Issuehunt content-->