### PR TITLE
Updating requirements for install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This is both a command-line app and a Swift package.
 
 It correctly handles getting the active wallpaper even when the wallpaper is set to a directory.
 
-*Requires macOS 10.14.4 or later.*
+*Requires XCode 13.0, and thus macOS > 10.15.*
 
 ## CLI
 


### PR DESCRIPTION
At least presently on my 10.15.7 MBP, I get an error 

```
wallpaper: A full installation of Xcode.app 13.0 is required to compile
this software. Installing just the Command Line Tools is not sufficient.

Xcode 13.0 cannot be installed on macOS 10.15.
You must upgrade your version of macOS.
```

so I upgrade the requirements for others in the future.